### PR TITLE
Replaces read_only usage with attr usage

### DIFF
--- a/src/TwoMartens/Bundle/CoreBundle/Form/Type/GroupType.php
+++ b/src/TwoMartens/Bundle/CoreBundle/Form/Type/GroupType.php
@@ -83,6 +83,10 @@ class GroupType extends AbstractType
                 'translation_domain' => 'TwoMartensCoreBundle'
             ]
         );
+        $attr = [];
+        if ($isEditForm) {
+            $attr['readonly'] = 'readonly';
+        }
         $builder->add(
             'roleName',
             TextType::class,
@@ -90,7 +94,7 @@ class GroupType extends AbstractType
                 'label' => 'acp.group.roleName',
                 'mapped' => true,
                 'required' => true,
-                'read_only' => $isEditForm,
+                'attr' => $attr,
                 'data' => $group->getRoleName(),
                 'translation_domain' => 'TwoMartensCoreBundle'
             ]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | #70
| License       | MIT
| Doc PR        |

The read_only option has been removed for
TextType in Symfony 3. This change follows up on
that.