### PR TITLE
Made 2WP Twig extension ready for Twig 2.0

### DIFF
--- a/src/TwoMartens/Bundle/CoreBundle/Twig/TwoMartensCoreBundleExtension.php
+++ b/src/TwoMartens/Bundle/CoreBundle/Twig/TwoMartensCoreBundleExtension.php
@@ -15,7 +15,7 @@ namespace TwoMartens\Bundle\CoreBundle\Twig;
  *
  * @author Jim Martens <github@2martens.de>
  */
-class TwoMartensCoreBundleExtension extends \Twig_Extension
+class TwoMartensCoreBundleExtension extends \Twig_Extension implements \Twig_Extension_GlobalsInterface
 {
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | #69
| License       | MIT
| Doc PR        | 

getGlobals method was moved from Twig_Extension to Twig_Extension_GlobalsInterface. This change follows up on that.